### PR TITLE
Fix build errors in Docker and local environment

### DIFF
--- a/src/ElasticPersonalization.Infrastructure/Data/ContentActionsDbContextFactory.cs
+++ b/src/ElasticPersonalization.Infrastructure/Data/ContentActionsDbContextFactory.cs
@@ -14,7 +14,7 @@ namespace ElasticPersonalization.Infrastructure.Data
             string environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Development";
 
             // Build configuration
-            IConfigurationRoot configuration = new ConfigurationBuilder()
+            IConfigurationRoot configuration = new Microsoft.Extensions.Configuration.ConfigurationBuilder()
                 .SetBasePath(Directory.GetCurrentDirectory())
                 .AddJsonFile("appsettings.json", optional: false)
                 .AddJsonFile($"appsettings.{environment}.json", optional: true)

--- a/src/ElasticPersonalization.Infrastructure/Services/PersonalizationService.cs
+++ b/src/ElasticPersonalization.Infrastructure/Services/PersonalizationService.cs
@@ -442,7 +442,8 @@ namespace ElasticPersonalization.Infrastructure.Services
                 Origin = DateTime.UtcNow,
                 Scale = "7d", // 7 days
                 Decay = 0.5,
-                Weight = 1.0
+                // Remove Weight property as it's not supported in this version of NEST
+                // Weight = 1.0
             });
 
             return functions;


### PR DESCRIPTION
This PR addresses the build errors you're encountering when trying to build the project locally or in Docker.

## Fixes:

1. **Missing ConfigurationBuilder reference:**
   - Added the fully qualified name `Microsoft.Extensions.Configuration.ConfigurationBuilder` to fix the error in `ContentActionsDbContextFactory.cs`

2. **FunctionScoreQuery 'Weight' property issue:**
   - Removed the `Weight` property from `GaussDateDecayFunction` in `PersonalizationService.cs` as it's not supported in the current NEST version (7.17.5)

These changes should allow the project to build successfully. The warning about using `-o /app/build` with a solution file is just a warning and doesn't block the build.

To test this fix:
1. Pull this branch
2. Run the build command again: `dotnet build "ElasticPersonalization.sln" -c Release`