### PR TITLE
Fix HealthController build errors with strongly-typed models

### DIFF
--- a/src/ElasticPersonalization.API/Models/HealthCheckResponse.cs
+++ b/src/ElasticPersonalization.API/Models/HealthCheckResponse.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace ElasticPersonalization.API.Models
+{
+    public class HealthCheckResponse
+    {
+        public string Status { get; set; } = "Healthy";
+        public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+        public ComponentsStatus Components { get; set; } = new ComponentsStatus();
+    }
+
+    public class ComponentsStatus
+    {
+        public ComponentStatus Api { get; set; } = new ComponentStatus { Status = "Healthy" };
+        public ComponentStatus Database { get; set; } = new ComponentStatus();
+        public ComponentStatus Elasticsearch { get; set; } = new ComponentStatus();
+    }
+
+    public class ComponentStatus
+    {
+        public string Status { get; set; } = "Unhealthy";
+        public string Message { get; set; } = "Not checked";
+        public string ClusterName { get; set; }
+        public int? NumberOfNodes { get; set; }
+    }
+}


### PR DESCRIPTION
This PR fixes the build errors in the HealthController by implementing strongly-typed models instead of anonymous objects.

## Changes

1. Created a new `HealthCheckResponse` class with proper models for all components
2. Updated the HealthController to use these strongly-typed models
3. Changed the return types of health check methods from `object` to specific `ComponentStatus` types

## Problem

The build was failing with these errors:
```
/src/src/ElasticPersonalization.API/Controllers/HealthController.cs(49,48): error CS1061: 'object' does not contain a definition for 'Status' and no accessible extension method 'Status' accepting a first argument of type 'object' could be found
/src/src/ElasticPersonalization.API/Controllers/HealthController.cs(50,53): error CS1061: 'object' does not contain a definition for 'Status' and no accessible extension method 'Status' accepting a first argument of type 'object' could be found
```

The issue was that the compiler couldn't determine that the anonymous objects returned from `CheckDatabaseHealthAsync()` and `CheckElasticsearchHealthAsync()` would have a `Status` property. By creating strongly-typed models, we ensure the compiler knows exactly what properties are available.

## How to Test

1. Build the project with Docker:
```
docker build -t elastic-personalization-api .
```

2. Run the API and test the health endpoint:
```
GET /api/health
```