### PR TITLE
Fix Entity Framework Include statements for non-navigation properties

### DIFF
--- a/src/ElasticPersonalization.Infrastructure/Services/PersonalizationService.cs
+++ b/src/ElasticPersonalization.Infrastructure/Services/PersonalizationService.cs
@@ -37,10 +37,8 @@ namespace ElasticPersonalization.Infrastructure.Services
         {
             try
             {
-                // Get user data including preferences, interests, and interactions
+                // Get user data including interactions - remove invalid includes for Preferences and Interests
                 var user = await _dbContext.Users
-                    .Include(u => u.Preferences)
-                    .Include(u => u.Interests)
                     .Include(u => u.Shares)
                     .Include(u => u.Likes)
                     .Include(u => u.Comments)
@@ -127,10 +125,8 @@ namespace ElasticPersonalization.Infrastructure.Services
         {
             try
             {
-                // Get user data
+                // Get user data - remove invalid includes for Preferences and Interests
                 var user = await _dbContext.Users
-                    .Include(u => u.Preferences)
-                    .Include(u => u.Interests)
                     .Include(u => u.Shares.Where(s => s.ContentId == contentId))
                     .Include(u => u.Likes.Where(l => l.ContentId == contentId))
                     .Include(u => u.Comments.Where(c => c.ContentId == contentId))
@@ -207,10 +203,8 @@ namespace ElasticPersonalization.Infrastructure.Services
         {
             try
             {
-                // Get user with all relevant data
+                // Get user with all relevant data - remove invalid includes for Preferences and Interests
                 var user = await _dbContext.Users
-                    .Include(u => u.Preferences)
-                    .Include(u => u.Interests)
                     .Include(u => u.Shares)
                     .Include(u => u.Likes)
                     .Include(u => u.Comments)


### PR DESCRIPTION
This PR fixes the Entity Framework Core error that was preventing the application from functioning correctly.

## Problem

The application was failing with the following error:
```
The expression 'u.Preferences' is invalid inside an 'Include' operation, since it does not represent a property access
```

## Root Cause

The issue is that `Preferences` and `Interests` are defined in the `User` class as `List<string>` properties:
```csharp
public List<string> Preferences { get; set; } = new();
public List<string> Interests { get; set; } = new();
```

However, they were being used in `Include()` statements in the `PersonalizationService`:
```csharp
var user = await _dbContext.Users
    .Include(u => u.Preferences)  // Invalid - not a navigation property
    .Include(u => u.Interests)    // Invalid - not a navigation property
    // ...
```

The `Include()` method is only meant for navigation properties (relationships between entities), not for simple collections of primitive types like strings.

## Fix

I've removed the invalid `Include()` calls for `Preferences` and `Interests` in three methods:
1. `GetPersonalizedFeedAsync`
2. `CalculatePersonalizationScoreAsync`
3. `GetPersonalizationFactorsAsync`

Since `Preferences` and `Interests` are scalar collections directly on the User entity, they will be loaded automatically without needing explicit includes.

This change should resolve the Entity Framework error and allow the application to work correctly.